### PR TITLE
메인화면에서 메인농가의 센서값 조회

### DIFF
--- a/src/main/java/com/ezfarm/ezfarmback/facility/controller/FacilityController.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/controller/FacilityController.java
@@ -83,4 +83,16 @@ public class FacilityController {
 
         return ResponseEntity.ok(facilityResponse);
     }
+
+    @ApiOperation(value = "메인 농가 최근 센서값 조회")
+    @ApiResponses({
+        @ApiResponse(code = 404, message = "존재하지 않는 농가입니다."),
+        @ApiResponse(code = 500, message = "서버에 문제가 생겼습니다."),
+    })
+    @GetMapping()
+    public ResponseEntity<FacilityResponse> findMainFarmFacility(@CurrentUser User user) {
+        FacilityResponse facilityResponse = facilityService.findMainFarmFacility(user);
+
+        return ResponseEntity.ok(facilityResponse);
+    }
 }

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/FacilityAvg.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/FacilityAvg.java
@@ -1,6 +1,7 @@
 package com.ezfarm.ezfarmback.facility.domain;
 
 import com.ezfarm.ezfarmback.facility.domain.hour.Facility;
+import com.ezfarm.ezfarmback.facility.dto.FacilityAvgSearchResponse;
 import javax.persistence.Embeddable;
 import lombok.Getter;
 
@@ -27,6 +28,15 @@ public class FacilityAvg {
         this.avgCo2 = 0;
         this.avgPh = 0;
         this.avgMos = 0;
+    }
+
+    public FacilityAvg(FacilityAvgSearchResponse facilityAvgSearchResponse) {
+        this.avgTmp = facilityAvgSearchResponse.getAvgTmp();
+        this.avgHumidity = facilityAvgSearchResponse.getAvgHumidity();
+        this.avgIlluminance = facilityAvgSearchResponse.getAvgIlluminance();
+        this.avgCo2 = facilityAvgSearchResponse.getAvgCo2();
+        this.avgPh = facilityAvgSearchResponse.getAvgPh();
+        this.avgMos = facilityAvgSearchResponse.getAvgMos();
     }
 
     public void sum(Facility facility) {

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/day/FacilityDayAvgRepository.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/day/FacilityDayAvgRepository.java
@@ -1,5 +1,6 @@
 package com.ezfarm.ezfarmback.facility.domain.day;
 
+import com.ezfarm.ezfarmback.facility.domain.week.FacilityWeekRepositoryCustom;
 import com.ezfarm.ezfarmback.facility.dto.FacilityPeriodResponse;
 import com.ezfarm.ezfarmback.farm.domain.Farm;
 import java.util.List;

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/hour/FacilityDayRepositoryCustom.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/hour/FacilityDayRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.ezfarm.ezfarmback.facility.domain.hour;
+
+import com.ezfarm.ezfarmback.facility.dto.FacilityAvgSearchResponse;
+import java.util.List;
+
+public interface FacilityDayRepositoryCustom {
+
+  List<FacilityAvgSearchResponse> findDayAvgGroupByFarm();
+
+}

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/hour/FacilityDayRepositoryCustomImpl.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/hour/FacilityDayRepositoryCustomImpl.java
@@ -1,0 +1,37 @@
+package com.ezfarm.ezfarmback.facility.domain.hour;
+
+import static com.ezfarm.ezfarmback.facility.domain.hour.QFacility.facility;
+
+import com.ezfarm.ezfarmback.facility.dto.FacilityAvgSearchResponse;
+import com.ezfarm.ezfarmback.facility.dto.QFacilityAvgSearchResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class FacilityDayRepositoryCustomImpl implements FacilityDayRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<FacilityAvgSearchResponse> findDayAvgGroupByFarm() {
+    return queryFactory
+        .select(new QFacilityAvgSearchResponse(
+            facility.farm,
+            facility.tmp.avg().floatValue(),
+            facility.humidity.avg().floatValue(),
+            facility.illuminance.avg().floatValue(),
+            facility.co2.avg().floatValue(),
+            facility.ph.avg().floatValue(),
+            facility.mos.avg().floatValue()
+        ))
+        .from(facility)
+        .where(
+            facility.measureDate.between(LocalDateTime.now().minusHours(24), LocalDateTime.now())
+        )
+        .groupBy(facility.farm)
+        .fetch();
+  }
+
+}

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/hour/FacilityRepository.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/hour/FacilityRepository.java
@@ -1,0 +1,12 @@
+package com.ezfarm.ezfarmback.facility.domain.hour;
+
+import com.ezfarm.ezfarmback.farm.domain.Farm;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FacilityRepository extends JpaRepository<Facility, Long> {
+
+  Optional<Facility> findTop1ByFarmOrderByMeasureDateDesc(Farm mainFarm);
+
+  boolean existsByFarm(Farm mainFarm);
+}

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/hour/FacilityRepository.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/hour/FacilityRepository.java
@@ -4,7 +4,8 @@ import com.ezfarm.ezfarmback.farm.domain.Farm;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FacilityRepository extends JpaRepository<Facility, Long> {
+public interface FacilityRepository extends JpaRepository<Facility, Long>,
+    FacilityDayRepositoryCustom {
 
   Optional<Facility> findTop1ByFarmOrderByMeasureDateDesc(Farm mainFarm);
 

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/month/FacilityMonthAvgRepository.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/month/FacilityMonthAvgRepository.java
@@ -1,10 +1,12 @@
 package com.ezfarm.ezfarmback.facility.domain.month;
 
+import com.ezfarm.ezfarmback.facility.domain.week.FacilityWeekRepositoryCustom;
 import com.ezfarm.ezfarmback.farm.domain.Farm;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FacilityMonthAvgRepository extends JpaRepository<FacilityMonthAvg, Long> {
+public interface FacilityMonthAvgRepository extends JpaRepository<FacilityMonthAvg, Long>,
+    FacilityMonthRepositoryCustom {
 
     List<FacilityMonthAvg> findAllByFarmAndMeasureDateStartsWith(Farm farm, String measureDate);
 

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/month/FacilityMonthRepositoryCustom.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/month/FacilityMonthRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.ezfarm.ezfarmback.facility.domain.month;
+
+import com.ezfarm.ezfarmback.facility.dto.FacilityAvgSearchResponse;
+import java.util.List;
+
+public interface FacilityMonthRepositoryCustom {
+
+  List<FacilityAvgSearchResponse> findMonthAvgGroupByFarm();
+}

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/month/FacilityMonthRepositoryCustomImpl.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/month/FacilityMonthRepositoryCustomImpl.java
@@ -1,0 +1,39 @@
+package com.ezfarm.ezfarmback.facility.domain.month;
+
+import static com.ezfarm.ezfarmback.facility.domain.week.QFacilityWeekAvg.facilityWeekAvg;
+
+import com.ezfarm.ezfarmback.facility.dto.FacilityAvgSearchResponse;
+import com.ezfarm.ezfarmback.facility.dto.QFacilityAvgSearchResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.joda.time.LocalDate;
+
+@RequiredArgsConstructor
+public class FacilityMonthRepositoryCustomImpl implements FacilityMonthRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<FacilityAvgSearchResponse> findMonthAvgGroupByFarm() {
+    return queryFactory
+        .select(new QFacilityAvgSearchResponse(
+            facilityWeekAvg.farm,
+            facilityWeekAvg.facilityAvg.avgTmp.avg().floatValue(),
+            facilityWeekAvg.facilityAvg.avgTmp.avg().floatValue(),
+            facilityWeekAvg.facilityAvg.avgTmp.avg().floatValue(),
+            facilityWeekAvg.facilityAvg.avgTmp.avg().floatValue(),
+            facilityWeekAvg.facilityAvg.avgTmp.avg().floatValue(),
+            facilityWeekAvg.facilityAvg.avgTmp.avg().floatValue()
+        ))
+        .from(facilityWeekAvg)
+        .where(
+            facilityWeekAvg.measureDate.like(LocalDateTime.now().minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-%")))
+        )
+        .groupBy(facilityWeekAvg.farm)
+        .fetch();
+  }
+
+}

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/week/FacilityWeekAvgRepository.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/week/FacilityWeekAvgRepository.java
@@ -1,5 +1,6 @@
 package com.ezfarm.ezfarmback.facility.domain.week;
 
+import com.ezfarm.ezfarmback.facility.domain.month.FacilityMonthRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FacilityWeekAvgRepository extends JpaRepository<FacilityWeekAvg, Long>,

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/week/FacilityWeekRepositoryCustom.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/week/FacilityWeekRepositoryCustom.java
@@ -1,5 +1,7 @@
 package com.ezfarm.ezfarmback.facility.domain.week;
 
+import com.ezfarm.ezfarmback.facility.domain.week.FacilityWeekAvg;
+import com.ezfarm.ezfarmback.facility.dto.FacilityAvgSearchResponse;
 import com.ezfarm.ezfarmback.facility.dto.FacilityWeekAvgRequest;
 import com.ezfarm.ezfarmback.farm.domain.Farm;
 import java.util.List;
@@ -8,4 +10,6 @@ public interface FacilityWeekRepositoryCustom {
 
     List<FacilityWeekAvg> findAllByFarmAndMeasureDateStartsWith(Farm farm,
         FacilityWeekAvgRequest facilityWeekAvgRequest);
+
+    List<FacilityAvgSearchResponse> findWeekAvgGroupByFarm();
 }

--- a/src/main/java/com/ezfarm/ezfarmback/facility/domain/week/FacilityWeekRepositoryCustomImpl.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/domain/week/FacilityWeekRepositoryCustomImpl.java
@@ -1,11 +1,15 @@
 package com.ezfarm.ezfarmback.facility.domain.week;
 
 import static com.ezfarm.ezfarmback.facility.domain.week.QFacilityWeekAvg.facilityWeekAvg;
+import static com.ezfarm.ezfarmback.facility.domain.day.QFacilityDayAvg.facilityDayAvg;
 
+import com.ezfarm.ezfarmback.facility.dto.FacilityAvgSearchResponse;
 import com.ezfarm.ezfarmback.facility.dto.FacilityWeekAvgRequest;
+import com.ezfarm.ezfarmback.facility.dto.QFacilityAvgSearchResponse;
 import com.ezfarm.ezfarmback.farm.domain.Farm;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
@@ -30,5 +34,25 @@ public class FacilityWeekRepositoryCustomImpl implements FacilityWeekRepositoryC
 
     public static BooleanExpression measureDateEq(String measureDate) {
         return measureDate != null ? facilityWeekAvg.measureDate.like(measureDate + "%") : null;
+    }
+
+    @Override
+    public List<FacilityAvgSearchResponse> findWeekAvgGroupByFarm() {
+        return queryFactory
+            .select(new QFacilityAvgSearchResponse(
+                facilityDayAvg.farm,
+                facilityDayAvg.facilityAvg.avgTmp.avg().floatValue(),
+                facilityDayAvg.facilityAvg.avgTmp.avg().floatValue(),
+                facilityDayAvg.facilityAvg.avgTmp.avg().floatValue(),
+                facilityDayAvg.facilityAvg.avgTmp.avg().floatValue(),
+                facilityDayAvg.facilityAvg.avgTmp.avg().floatValue(),
+                facilityDayAvg.facilityAvg.avgTmp.avg().floatValue()
+            ))
+            .from(facilityDayAvg)
+            .where(
+                facilityDayAvg.measureDate.between(LocalDateTime.now().minusDays(7).toString(), LocalDateTime.now().toString())
+            )
+            .groupBy(facilityDayAvg.farm)
+            .fetch();
     }
 }

--- a/src/main/java/com/ezfarm/ezfarmback/facility/dto/FacilityAvgSearchResponse.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/dto/FacilityAvgSearchResponse.java
@@ -1,0 +1,42 @@
+package com.ezfarm.ezfarmback.facility.dto;
+
+import com.ezfarm.ezfarmback.farm.domain.Farm;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class FacilityAvgSearchResponse {
+
+  private Farm farm;
+
+  private float avgTmp;
+
+  private float avgHumidity;
+
+  private float avgIlluminance;
+
+  private float avgCo2;
+
+  private float avgPh;
+
+  private float avgMos;
+
+  private String measureDate;
+
+  public void setMeasureDate(String measureDate) {
+    this.measureDate = measureDate;
+  }
+
+  @QueryProjection
+  public FacilityAvgSearchResponse(Farm farm, float tmp, float humidity, float illuminance, float co2, float ph, float mos) {
+    this.farm = farm;
+    this.avgTmp = tmp;
+    this.avgHumidity = humidity;
+    this.avgIlluminance = illuminance;
+    this.avgCo2 = co2;
+    this.avgPh = ph;
+    this.avgMos = mos;
+  }
+}

--- a/src/main/java/com/ezfarm/ezfarmback/facility/dto/FacilityResponse.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/dto/FacilityResponse.java
@@ -1,5 +1,6 @@
 package com.ezfarm.ezfarmback.facility.dto;
 
+import com.ezfarm.ezfarmback.facility.domain.hour.Facility;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -44,6 +45,18 @@ public class FacilityResponse {
             .ph(split[4].trim())
             .mos(split[5].trim())
             .measureDate(split[6].trim())
+            .build();
+    }
+
+    public static FacilityResponse of(Facility facility) {
+        return FacilityResponse.builder()
+            .tmp(Float.toString(facility.getTmp()))
+            .humidity(Float.toString(facility.getHumidity()))
+            .illuminance(Float.toString(facility.getIlluminance()))
+            .co2(Float.toString(facility.getCo2()))
+            .ph(Float.toString(facility.getPh()))
+            .mos(Float.toString(facility.getMos()))
+            .measureDate(facility.getMeasureDate().toString())
             .build();
     }
 }

--- a/src/main/java/com/ezfarm/ezfarmback/facility/scheduler/FacilityAvgScheduler.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/scheduler/FacilityAvgScheduler.java
@@ -1,0 +1,87 @@
+package com.ezfarm.ezfarmback.facility.scheduler;
+
+import com.ezfarm.ezfarmback.facility.domain.FacilityAvg;
+import com.ezfarm.ezfarmback.facility.domain.day.FacilityDayAvg;
+import com.ezfarm.ezfarmback.facility.domain.day.FacilityDayAvgRepository;
+import com.ezfarm.ezfarmback.facility.domain.hour.FacilityRepository;
+import com.ezfarm.ezfarmback.facility.domain.month.FacilityMonthAvg;
+import com.ezfarm.ezfarmback.facility.domain.month.FacilityMonthAvgRepository;
+import com.ezfarm.ezfarmback.facility.domain.week.FacilityWeekAvg;
+import com.ezfarm.ezfarmback.facility.domain.week.FacilityWeekAvgRepository;
+import com.ezfarm.ezfarmback.facility.dto.FacilityAvgSearchResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Transactional
+@Slf4j
+@RequiredArgsConstructor
+@EnableScheduling
+@Component
+public class FacilityAvgScheduler {
+
+  private final FacilityRepository facilityRepository;
+  private final FacilityDayAvgRepository facilityDayAvgRepository;
+  private final FacilityWeekAvgRepository facilityWeekAvgRepository;
+  private final FacilityMonthAvgRepository facilityMonthAvgRepository;
+
+  //cron : seconds, minutes, hours, day of month, month, day of week
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  public void FacilityDayAvgScheduler() {
+    log.info("{} start - 시설 데이터 일 평균 계산", LocalDateTime.now());
+    List<FacilityAvgSearchResponse> responses = facilityRepository.findDayAvgGroupByFarm();
+    List<FacilityDayAvg> facilityDayAvgs = responses.stream().map(response -> {
+      FacilityAvg facilityAvg = new FacilityAvg(response);
+      return FacilityDayAvg.builder()
+          .farm(response.getFarm())
+          .facilityAvg(facilityAvg)
+          .measureDate(LocalDateTime.now())
+          .build();
+    }).collect(Collectors.toList());
+
+    facilityDayAvgRepository.saveAll(facilityDayAvgs);
+
+    log.info("{} end - 시설 데이터 일 평균 계산", LocalDateTime.now());
+  }
+
+  @Scheduled(cron = "0 0 0 ? * WED", zone = "Asia/Seoul")
+  public void FacilityWeekAvgScheduler() {
+    log.info("{} start - 시설 데이터 주 평균 계산", LocalDateTime.now());
+    List<FacilityAvgSearchResponse> responses = facilityWeekAvgRepository.findWeekAvgGroupByFarm();
+    List<FacilityWeekAvg> facilityWeekAvgs = responses.stream().map(response -> {
+      FacilityAvg facilityAvg = new FacilityAvg(response);
+      return FacilityWeekAvg.builder()
+          .farm(response.getFarm())
+          .facilityAvg(facilityAvg)
+          .measureDate(LocalDateTime.now())
+          .build();
+    }).collect(Collectors.toList());
+
+    facilityWeekAvgRepository.saveAll(facilityWeekAvgs);
+
+    log.info("{} end - 시설 데이터 주 평균 계산", LocalDateTime.now());
+  }
+
+  @Scheduled(cron = "0 10 0 1 * *", zone = "Asia/Seoul")
+  public void FacilityMonthAvgScheduler() {
+    log.info("{} start - 시설 데이터 월 평균 계산", LocalDateTime.now());
+    List<FacilityAvgSearchResponse> responses = facilityMonthAvgRepository.findMonthAvgGroupByFarm();
+    List<FacilityMonthAvg> facilityMonthAvgs = responses.stream().map(response -> {
+      FacilityAvg facilityAvg = new FacilityAvg(response);
+      return FacilityMonthAvg.builder()
+          .farm(response.getFarm())
+          .facilityAvg(facilityAvg)
+          .measureDate(LocalDateTime.now())
+          .build();
+    }).collect(Collectors.toList());
+    facilityMonthAvgRepository.saveAll(facilityMonthAvgs);
+
+    log.info("{} end - 시설 데이터 월 평균 계산", LocalDateTime.now());
+  }
+}

--- a/src/main/java/com/ezfarm/ezfarmback/facility/service/FacilityService.java
+++ b/src/main/java/com/ezfarm/ezfarmback/facility/service/FacilityService.java
@@ -22,7 +22,6 @@ import com.ezfarm.ezfarmback.farm.domain.FarmRepository;
 import com.ezfarm.ezfarmback.user.domain.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/ezfarm/ezfarmback/farm/domain/FarmRepository.java
+++ b/src/main/java/com/ezfarm/ezfarmback/farm/domain/FarmRepository.java
@@ -12,4 +12,5 @@ public interface FarmRepository extends JpaRepository<Farm, Long>, FarmRepositor
 
     Optional<Farm> findByIsMainAndUser(boolean isMain, User user);
 
+    boolean existsByUser(User user);
 }

--- a/src/main/java/com/ezfarm/ezfarmback/farm/service/FarmService.java
+++ b/src/main/java/com/ezfarm/ezfarmback/farm/service/FarmService.java
@@ -77,6 +77,10 @@ public class FarmService {
         if (farmRequest.isMain()) {
             Optional<Farm> prevMainFarm = farmRepository.findByIsMainAndUser(true, user);
             prevMainFarm.ifPresent(value -> value.setMain(false));
+        } else {
+            if (!farmRepository.existsByUser(user)) {
+                farmRequest.setMain(true);
+            }
         }
     }
 

--- a/src/test/java/com/ezfarm/ezfarmback/facility/acceptance/FacilityAcceptanceTest.java
+++ b/src/test/java/com/ezfarm/ezfarmback/facility/acceptance/FacilityAcceptanceTest.java
@@ -17,7 +17,6 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import javax.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/ezfarm/ezfarmback/facility/acceptance/FacilityAcceptanceTest.java
+++ b/src/test/java/com/ezfarm/ezfarmback/facility/acceptance/FacilityAcceptanceTest.java
@@ -1,0 +1,100 @@
+package com.ezfarm.ezfarmback.facility.acceptance;
+
+import com.ezfarm.ezfarmback.common.db.CommonAcceptanceTest;
+import com.ezfarm.ezfarmback.facility.acceptance.step.FacilityAcceptanceStep;
+import com.ezfarm.ezfarmback.facility.domain.hour.Facility;
+import com.ezfarm.ezfarmback.facility.domain.hour.FacilityRepository;
+import com.ezfarm.ezfarmback.facility.dto.FacilityResponse;
+import com.ezfarm.ezfarmback.farm.acceptance.step.FarmAcceptanceStep;
+import com.ezfarm.ezfarmback.farm.domain.Farm;
+import com.ezfarm.ezfarmback.farm.domain.FarmRepository;
+import com.ezfarm.ezfarmback.farm.domain.enums.CropType;
+import com.ezfarm.ezfarmback.farm.domain.enums.FarmType;
+import com.ezfarm.ezfarmback.farm.dto.FarmRequest;
+import com.ezfarm.ezfarmback.user.dto.AuthResponse;
+import com.ezfarm.ezfarmback.user.dto.LoginRequest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import javax.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("센서값 통합 테스트")
+public class FacilityAcceptanceTest extends CommonAcceptanceTest {
+
+  AuthResponse authResponse;
+
+  FarmRequest farmRequest;
+
+  Facility facility;
+
+  @Autowired
+  FacilityRepository facilityRepository;
+
+  @Autowired
+  FarmRepository farmRepository;
+
+  @BeforeEach
+  @Override
+  public void setUp() {
+    super.setUp();
+    LoginRequest loginRequest = new LoginRequest("test1@email.com", "비밀번호");
+    authResponse = getAuthResponse(loginRequest);
+
+    farmRequest = new FarmRequest(
+        "경기",
+        "테스트 이름",
+        "010-2222-2222",
+        "100",
+        true,
+        FarmType.GLASS,
+        CropType.PAPRIKA,
+        LocalDate.now()
+    );
+
+  }
+
+  @DisplayName("메인 농가의 센서값을 조회한다.(메인페이지)")
+  @Test
+  void findMainFarmFaciltiy() throws Exception {
+    ExtractableResponse<Response> farmResponse = FarmAcceptanceStep
+        .requestToCreateFarm(authResponse, farmRequest, objectMapper);
+    Long farmId = FarmAcceptanceStep.getLocation(farmResponse);
+    requestToCreateFacility(farmId);
+
+    ExtractableResponse<Response> response = FacilityAcceptanceStep.requestToFindMainFarmFacility(authResponse);
+    FacilityResponse facilityResponse = response.jsonPath().getObject(".", FacilityResponse.class);
+    FacilityAcceptanceStep.assertThatFindMainFarmFacility(facilityResponse, facility);
+  }
+
+  void requestToCreateFacility(Long farmId) {
+    Farm farm = farmRepository.findById(farmId).get();
+    facility = Facility.builder()
+        .farm(farm)
+        .tmp(21.4f)
+        .humidity(12.5f)
+        .illuminance(11f)
+        .co2(16.2f)
+        .ph(18.9f)
+        .mos(55.1f)
+        .measureDate(LocalDateTime.of(2021, 8, 20, 19, 19))
+        .build();
+    facilityRepository.save(facility);
+
+    Facility oldFacility = Facility.builder()
+        .farm(farm)
+        .tmp(11.4f)
+        .humidity(18.5f)
+        .illuminance(72.2f)
+        .co2(26.2f)
+        .ph(30f)
+        .mos(55f)
+        .measureDate(LocalDateTime.of(2020, 8, 20, 19, 19))
+        .build();
+    facilityRepository.save(oldFacility);
+  }
+}

--- a/src/test/java/com/ezfarm/ezfarmback/facility/acceptance/step/FacilityAcceptanceStep.java
+++ b/src/test/java/com/ezfarm/ezfarmback/facility/acceptance/step/FacilityAcceptanceStep.java
@@ -1,0 +1,37 @@
+package com.ezfarm.ezfarmback.facility.acceptance.step;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ezfarm.ezfarmback.facility.domain.hour.Facility;
+import com.ezfarm.ezfarmback.facility.dto.FacilityResponse;
+import com.ezfarm.ezfarmback.user.dto.AuthResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Assertions;
+
+public class FacilityAcceptanceStep {
+
+  public static ExtractableResponse<Response> requestToFindMainFarmFacility(AuthResponse authResponse) {
+    return given().log().all()
+        .header("Authorization",
+            authResponse.getTokenType() + " " + authResponse.getAccessToken())
+        .when()
+        .get(String.format("/api/facility"))
+        .then().log().all()
+        .extract();
+
+  }
+
+  public static void assertThatFindMainFarmFacility(FacilityResponse facilityResponse, Facility facility) {
+    Assertions.assertAll(
+        () -> assertThat(facilityResponse.getTmp()).isEqualTo(Float.toString(facility.getTmp())),
+        () -> assertThat(facilityResponse.getHumidity()).isEqualTo(Float.toString(facility.getHumidity())),
+        () -> assertThat(facilityResponse.getIlluminance()).isEqualTo(Float.toString(facility.getIlluminance())),
+        () -> assertThat(facilityResponse.getCo2()).isEqualTo(Float.toString(facility.getCo2())),
+        () -> assertThat(facilityResponse.getPh()).isEqualTo(Float.toString(facility.getPh())),
+        () -> assertThat(facilityResponse.getMos()).isEqualTo(Float.toString(facility.getMos())),
+        () -> assertThat(facilityResponse.getMeasureDate()).isEqualTo(facility.getMeasureDate().toString())
+    );
+  }
+}

--- a/src/test/java/com/ezfarm/ezfarmback/facility/controller/FacilityControllerTest.java
+++ b/src/test/java/com/ezfarm/ezfarmback/facility/controller/FacilityControllerTest.java
@@ -139,4 +139,17 @@ public class FacilityControllerTest extends CommonApiTest {
             .andExpect(status().isOk())
             .andDo(print());
     }
+
+    @WithMockCustomUser
+    @DisplayName("메인 농가의 최근 센서값을 조회한다.")
+    @Test
+    void findMainFarmFacility() throws Exception {
+        when(facilityService.findMainFarmFacility(any())).thenReturn(facilityResponse);
+
+        mockMvc.perform(get("/api/facility")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(facilityResponse)))
+            .andExpect(status().isOk())
+            .andDo(print());
+    }
 }

--- a/src/test/java/com/ezfarm/ezfarmback/facility/service/FacilityServiceTest.java
+++ b/src/test/java/com/ezfarm/ezfarmback/facility/service/FacilityServiceTest.java
@@ -3,6 +3,7 @@ package com.ezfarm.ezfarmback.facility.service;
 import static java.util.Optional.ofNullable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -10,6 +11,8 @@ import com.ezfarm.ezfarmback.common.utils.iot.IotUtils;
 import com.ezfarm.ezfarmback.facility.domain.FacilityAvg;
 import com.ezfarm.ezfarmback.facility.domain.day.FacilityDayAvg;
 import com.ezfarm.ezfarmback.facility.domain.day.FacilityDayAvgRepository;
+import com.ezfarm.ezfarmback.facility.domain.hour.Facility;
+import com.ezfarm.ezfarmback.facility.domain.hour.FacilityRepository;
 import com.ezfarm.ezfarmback.facility.domain.month.FacilityMonthAvg;
 import com.ezfarm.ezfarmback.facility.domain.month.FacilityMonthAvgRepository;
 import com.ezfarm.ezfarmback.facility.domain.week.FacilityWeekAvg;
@@ -54,6 +57,9 @@ public class FacilityServiceTest {
   @Mock
   private IotUtils iotUtils;
 
+  @Mock
+  private FacilityRepository facilityRepository;
+
   FacilityService facilityService;
 
   Farm farm;
@@ -63,7 +69,7 @@ public class FacilityServiceTest {
   @BeforeEach
   void setUp() {
     facilityService = new FacilityService(farmRepository, facilityDayAvgRepository,
-        facilityMonthAvgRepository, facilityWeekAvgRepository, iotUtils);
+        facilityMonthAvgRepository, facilityWeekAvgRepository, iotUtils, facilityRepository);
 
     user = User.builder()
         .id(1L)
@@ -202,6 +208,45 @@ public class FacilityServiceTest {
         () -> assertThat(facilityResponse.getPh()).isEqualTo("22.4"),
         () -> assertThat(facilityResponse.getMos()).isEqualTo("16.5"),
         () -> assertThat(facilityResponse.getMeasureDate()).isEqualTo("2021-08-12")
+    );
+  }
+
+  @DisplayName("메인 농가의 최근 센서값을 조회한다.(메인 페이지)")
+  @Test
+  void findMainFarmFacility() {
+    Farm mainFarm = Farm.builder()
+        .id(1L)
+        .user(user)
+        .name("메인 농가")
+        .address("서울")
+        .isMain(true)
+        .startDate(LocalDate.now())
+        .build();
+
+    Facility recentFacility = Facility.builder()
+        .farm(mainFarm)
+        .tmp(21.4F)
+        .humidity(12.5F)
+        .illuminance(11)
+        .co2(16.2f)
+        .ph(18.9f)
+        .mos(55.1f)
+        .measureDate(LocalDateTime.now())
+        .build();
+
+    when(farmRepository.findByIsMainAndUser(anyBoolean(), any())).thenReturn(ofNullable(mainFarm));
+    when(facilityRepository.findTop1ByFarmOrderByMeasureDateDesc(any())).thenReturn(ofNullable(recentFacility));
+
+    FacilityResponse facilityResponse = facilityService.findMainFarmFacility(user);
+
+    Assertions.assertAll(
+        () -> assertThat(facilityResponse.getHumidity()).isEqualTo(Float.toString(recentFacility.getHumidity())),
+        () -> assertThat(facilityResponse.getTmp()).isEqualTo(Float.toString(recentFacility.getTmp())),
+        () -> assertThat(facilityResponse.getIlluminance()).isEqualTo(Float.toString(recentFacility.getIlluminance())),
+        () -> assertThat(facilityResponse.getCo2()).isEqualTo(Float.toString(recentFacility.getCo2())),
+        () -> assertThat(facilityResponse.getPh()).isEqualTo(Float.toString(recentFacility.getPh())),
+        () -> assertThat(facilityResponse.getMos()).isEqualTo(Float.toString(recentFacility.getMos())),
+        () -> assertThat(facilityResponse.getMeasureDate()).isEqualTo(recentFacility.getMeasureDate().toString())
     );
   }
 }

--- a/src/test/java/com/ezfarm/ezfarmback/farm/acceptance/FarmAcceptanceTest.java
+++ b/src/test/java/com/ezfarm/ezfarmback/farm/acceptance/FarmAcceptanceTest.java
@@ -69,7 +69,7 @@ public class FarmAcceptanceTest extends CommonAcceptanceTest {
         FarmResponse farmResponse = findResponse.jsonPath().getObject(".", FarmResponse.class);
 
         AcceptanceStep.assertThatStatusIsCreated(createResponse);
-        FarmAcceptanceStep.assertThatFindMyFarm(farmResponse, vinylTomatoFarmRequest);
+        FarmAcceptanceStep.assertThatFindMyNewFarm(farmResponse, vinylTomatoFarmRequest);
     }
 
     @DisplayName("나의 농가를 수정한다.")
@@ -120,7 +120,7 @@ public class FarmAcceptanceTest extends CommonAcceptanceTest {
         FarmResponse farmResponse = response.jsonPath().getObject(".", FarmResponse.class);
 
         AcceptanceStep.assertThatStatusIsOk(response);
-        FarmAcceptanceStep.assertThatFindMyFarm(farmResponse, vinylTomatoFarmRequest);
+        FarmAcceptanceStep.assertThatFindMyNewFarm(farmResponse, vinylTomatoFarmRequest);
     }
 
     @DisplayName("농가를 삭제한다.")

--- a/src/test/java/com/ezfarm/ezfarmback/farm/acceptance/step/FarmAcceptanceStep.java
+++ b/src/test/java/com/ezfarm/ezfarmback/farm/acceptance/step/FarmAcceptanceStep.java
@@ -45,6 +45,19 @@ public class FarmAcceptanceStep {
         );
     }
 
+    public static void assertThatFindMyNewFarm(FarmResponse farmResponse, FarmRequest farmRequest) {
+        assertAll(
+            () -> assertThat(farmResponse.getAddress()).isEqualTo(farmRequest.getAddress()),
+            () -> assertThat(farmResponse.getName()).isEqualTo(farmRequest.getName()),
+            () -> assertThat(farmResponse.getStartDate()).isEqualTo(farmRequest.getStartDate()),
+            () -> assertThat(farmResponse.isMain()).isEqualTo(true),
+            () -> assertThat(farmResponse.getPhoneNumber()).isEqualTo(farmRequest.getPhoneNumber()),
+            () -> assertThat(farmResponse.getArea()).isEqualTo(farmRequest.getArea()),
+            () -> assertThat(farmResponse.getFarmType()).isEqualTo(farmRequest.getFarmType()),
+            () -> assertThat(farmResponse.getCropType()).isEqualTo(farmRequest.getCropType())
+        );
+    }
+
     public static void assertThatFindOtherFarms(List<FarmSearchResponse> farmSearchResponse,
         FarmRequest farmRequest) {
         assertAll(


### PR DESCRIPTION
### 예외

- 사용자의 농가가 없을 경우 -> INVALID_FARM_ID
- 메인농가의 센서값이 DB에 있지만 조회하지 못한 경우 -> INTERNAL_SERVER_ERROR

### null 처리

- 메인 농가의 센서값이 DB에 없으면 -> 빈 FacilityResponse 반환

### 수정된 부분

- 기존 : 농가를 생성할때 메인 농가 선택 여부에 따라 메인 농가가 설정됨
- 수정 후 : 첫번째 농가를 생성하면 default로 메인 농가로 설정